### PR TITLE
Feature/proxy support

### DIFF
--- a/satispay-sdk/lib/Request.php
+++ b/satispay-sdk/lib/Request.php
@@ -222,6 +222,12 @@ class Request {
       $curlOptions[CURLOPT_SSL_VERIFYPEER] = false;
     }
 
+    if (!empty("WP_PROXY_HOST")) $curlOptions[CURLOPT_PROXY] = WP_PROXY_HOST;
+    if (!empty("WP_PROXY_PORT")) $curlOptions[CURLOPT_PROXYPORT] = WP_PROXY_PORT;
+    if (!empty("WP_PROXY_USERNAME") && !empty("WP_PROXY_PASSWORD")) {
+      $curlOptions[CURLOPT_PROXYUSERPWD] = WP_PROXY_USERNAME . ":" . WP_PROXY_PASSWORD;
+    }
+
     $curlOptions[CURLOPT_HTTPHEADER] = $options["headers"];
     curl_setopt_array($curl, $curlOptions);
 

--- a/satispay-sdk/lib/Request.php
+++ b/satispay-sdk/lib/Request.php
@@ -149,7 +149,6 @@ class Request {
     if (!empty($options["body"])) {
       array_push($headers, "Content-Type: application/json");
       $body = json_encode($options["body"]);
-      array_push($headers, "Content-Length: ".strlen($body));
     }
 
     $sign = false;


### PR DESCRIPTION
As requested #3 I tried to implement curl PROXY support, based on wp-config.php configuration

Had to remove "Content-Length" manual setting (why is it there in the first place?), because it was breaking proxy communication.  
It gets automatically generated by cURL anyways