### PR TITLE
Update wc-satispay.php #5

### DIFF
--- a/wc-satispay.php
+++ b/wc-satispay.php
@@ -201,7 +201,7 @@ class WC_Satispay extends WC_Payment_Gateway {
       'callback_url' => $callbackUrl,
       'external_code' => $order->get_id(),
       'metadata' => array(
-        'order_id' => $order->get_id(),
+        'order_id' => apply_filters ( 'satispay_payment_metadata_order_id', $order->get_id(), $order ),
         'redirect_url' => $redirectUrl
       )
     ));

--- a/wc-satispay.php
+++ b/wc-satispay.php
@@ -18,8 +18,9 @@ class WC_Satispay extends WC_Payment_Gateway {
     );
 
     $this->title                = $this->method_title;
-    $this->description          = $this->method_description;
+    $this->description          = $this->get_option('description');
     $this->icon                 = plugins_url('/logo.png', __FILE__);
+    $this->enabled              = $this->get_option( 'enabled' );
 
     $this->init_form_fields();
     $this->init_settings();
@@ -62,7 +63,12 @@ class WC_Satispay extends WC_Payment_Gateway {
         'type' => 'text',
         'description' => sprintf(__('Get a six characters Activation Code from Online Shop section on <a href="%s" target="_blank">Satispay Dashboard</a>.', 'woo-satispay'), 'https://business.satispay.com')
       ),
-      
+      'description' => array(
+        'title' => __('Description', 'woo-satispay'),
+        'type' => 'text',
+        'description' => __('Enter the description you want to show to customers in your checkout page.', 'woo-satispay') // TODO: add translation
+      ),
+
       // 'advanced' => array(
       //   'title' => __( 'Advanced Options', 'woo-satispay' ),
       //   'type' => 'title',
@@ -165,12 +171,12 @@ class WC_Satispay extends WC_Payment_Gateway {
       echo '<p>'.sprintf(__('Satispay is not correctly configured, get an Activation Code from Online Shop section on <a href="%s" target="_blank">Satispay Dashboard</a>', 'woo-satispay'), 'https://business.satispay.com').'</p>';
       echo '</div>';
     }
-    
+
     return parent::admin_options();
   }
 
   public function is_available() {
-    if (!$this->enabled) {
+    if ( 'no' === $this->enabled ) {
       return false;
     }
     return true;


### PR DESCRIPTION
As requested in #5, first 2 points:
- added description settings field, so now shop managers could choose which message to show to their customers (and, of course, you can add a default string);
![immagine](https://user-images.githubusercontent.com/80747609/125647894-b1a6e16c-d54d-452b-b636-7ef4df2e2d06.png)
![immagine](https://user-images.githubusercontent.com/80747609/125648171-ec9d5ebe-9afd-44e6-a49f-6e0ef779589c.png)
- fixed is_available(): enabled property was missing; so now if the payment gateway is not enabled, Satispay won't appear anymore.

Hoping that it will help, feel free to make the appropriate changes or ignore the request.
Thank you in advance for your attention.