### PR TITLE
Use new state 'wc-on-hold' instead of 'wc-pending' to avoid woocommer…

### DIFF
--- a/wc-satispay.php
+++ b/wc-satispay.php
@@ -72,7 +72,7 @@ class WC_Satispay extends WC_Payment_Gateway {
       $orders = wc_get_orders(array(
         'limit' => -1,
         'type' => 'shop_order',
-        'status' => array('wc-pending'),
+        'status' => array('wc-pending','wc-on-hold'),
         'date_created'=> $rangeStart .'...'. $rangeEnd
       )
     );
@@ -264,6 +264,7 @@ class WC_Satispay extends WC_Payment_Gateway {
     ));
 
     try {
+        $order->update_status('wc-on-hold');
         $order->set_transaction_id($payment->id);
         WC()->session->set('satispay_payment_id', $payment->id);
         $order->save();


### PR DESCRIPTION
Use new state 'wc-on-hold' instead of 'wc-pending' to avoid woocommerce payment restore